### PR TITLE
Get rsvps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,117 +1,92 @@
 var debug = require('debug')('gitevents-meetup');
 var moment = require('moment');
+
 var meetup = {};
-var config;
 
 meetup.config = null;
 
-meetup.init = function(cfg) {
-  if (!cfg) {
+meetup.init = function(config) {
+  if (!config) {
     return new Error('No configuration found');
-  } else {
-    this.config = cfg;
-    this.meetup = require('meetup-api')({
-      key: this.config.plugins.meetup.apikey
-    });
   }
+
+  this.config = config;
+  this.meetup = require('meetup-api')({
+    key: this.config.plugins.meetup.apikey
+  });
 };
 
 meetup.create = function create(event) {
   return new Promise(function(resolve, reject) {
     debug('create');
-
-    if (!isConfigured(this.config)) {
-      debug('GitEvents meetup.com plugin is not configured!');
-      reject(new Error('Meetup plugin is not configured'));
-      return;
-    }
-
-    if (!isEnabled(this.config)) {
-      debug('Plugin disabled. Exiting.');
-      reject(new Error('Meetup plugin is disabeld'));
-      return;
-    }
-
+    this.validateConfig();
     debug('Plugin enabled. Proceeding.');
 
-    var doorTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
-    var startTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
-    doorTime.hour(event.doorTime.split(':')[0]);
-    doorTime.minute(event.doorTime.split(':')[1]);
-    var differenceDoorStartTime = startTime.diff(doorTime);
-
-    var duration = moment.duration(event.duration);
-    duration.add(differenceDoorStartTime);
-
-    var meetupVenueId = resolveVenueId(event, this.config);
-
-    this.meetup.postEvent({
-      group_id: this.config.plugins.meetup.group_id,
-      name: event.name,
-      venue_visibility: 'public',
-      hosts: this.config.plugins.meetup.hosts.join(','),
-      group_urlname: event.organizer.url,
-      simple_html_description: this.config.plugins.meetup.simple_html_description,
-      time: doorTime.valueOf(),
-      duration: duration.asMilliseconds(),
-      publish_status: 'published',
-      venue_id: meetupVenueId
-    }, function(error, response) {
-      debug('Meetup:postEvent()');
-      if (error) {
-        debug(error);
-        return reject(error);
-      }
-      return resolve(response.id);
-    });
+    this.meetup.postEvent(
+      buildEventParams(this.config, event),
+      handlePostEventResponse(resolve, reject)
+    );
   }.bind(this));
 };
 
 meetup.getRSVPs = function getRSVPs(eventId) {
   return new Promise(function(resolve, reject) {
     debug('getRsvps');
-
-    if (!isConfigured(this.config)) {
-      debug('GitEvents meetup.com plugin is not configured!');
-      reject(new Error('Meetup plugin is not configured'));
-      return;
-    }
-
-    if (!isEnabled(this.config)) {
-      debug('Plugin disabled. Exiting.');
-      reject(new Error('Meetup plugin is disabeld'));
-      return;
-    }
-
+    this.validateConfig();
     debug('Plugin enabled. Proceeding.');
 
-    this.meetup.getRSVPs({
-      event_id: eventId
-    }, function(error, response) {
-      debug('Meetup:getRSVPs()');
-      if (error) {
-        debug(error);
-        return reject(error);
-      }
-
-      var rsvps = response.results.map(function(result) {
-        return {
-          name: result.member.name,
-          response: result.response
-        };
-      });
-
-      return resolve(rsvps);
-    });
+    this.meetup.getRSVPs(
+      { event_id: eventId },
+      handleGetRSVPsResponse(resolve, reject)
+    );
   }.bind(this));
 };
 
-function isConfigured(config) {
-  return Boolean(config.plugins.meetup);
+meetup.validateConfig = function() {
+  if (!Boolean(this.config.plugins.meetup)) {
+    debug('GitEvents meetup.com plugin is not configured!');
+    throw new Error('Meetup plugin is not configured');
+  }
+
+  if (this.config.plugins.meetup.enabled !== true) {
+    debug('Plugin disabled. Exiting.');
+    throw new Error('Meetup plugin is disabeld');
+  }
 }
 
-function isEnabled(config) {
-  return config.plugins.meetup.enabled === true;
+function buildEventParams(config, event) {
+  var doorTime = resolveDoorTime(event);
+  var duration = resolveDuration(event, doorTime);
+
+  return {
+    group_id: config.plugins.meetup.group_id,
+    name: event.name,
+    venue_visibility: 'public',
+    hosts: config.plugins.meetup.hosts.join(','),
+    group_urlname: event.organizer.url,
+    simple_html_description: config.plugins.meetup.simple_html_description,
+    time: doorTime.valueOf(),
+    duration: duration.asMilliseconds(),
+    publish_status: 'published',
+    venue_id: resolveVenueId(event, config)
+  };
+}
+
+function resolveDoorTime(event) {
+  var doorTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
+  doorTime.hour(event.doorTime.split(':')[0]);
+  doorTime.minute(event.doorTime.split(':')[1]);
+
+  return doorTime;
+}
+
+function resolveDuration(event, doorTime) {
+  var startTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
+  var differenceDoorStartTime = startTime.diff(doorTime);
+  var duration = moment.duration(event.duration);
+  duration.add(differenceDoorStartTime);
+
+  return duration;
 }
 
 function resolveVenueId(event, config) {
@@ -120,6 +95,36 @@ function resolveVenueId(event, config) {
   }
 
   return config.plugins.meetup.default_venue_id;
+}
+
+function handlePostEventResponse(resolve, reject) {
+  return function(error, response) {
+    debug('Meetup:postEvent()');
+    if (error) {
+      debug(error);
+      return reject(error);
+    }
+    return resolve(response.id);
+  }
+}
+
+function handleGetRSVPsResponse(resolve, reject) {
+  return function(error, response) {
+    debug('Meetup:getRSVPs()');
+    if (error) {
+      debug(error);
+      return reject(error);
+    }
+
+    var rsvps = response.results.map(function(result) {
+      return {
+        name: result.member.name,
+        response: result.response
+      };
+    });
+
+    return resolve(rsvps);
+  }
 }
 
 module.exports = exports = meetup;

--- a/index.js
+++ b/index.js
@@ -3,11 +3,16 @@ var moment = require('moment');
 var meetup = {};
 var config;
 
+meetup.config = null;
+
 meetup.init = function(cfg) {
   if (!cfg) {
     return new Error('No configuration found');
   } else {
-    config = cfg;
+    this.config = cfg;
+    this.meetup = require('meetup-api')({
+      key: this.config.plugins.meetup.apikey
+    });
   }
 };
 
@@ -15,58 +20,106 @@ meetup.create = function create(event) {
   return new Promise(function(resolve, reject) {
     debug('create');
 
-    if (!config.plugins.meetup) {
-      debug('GitEvents meetup.com plugin is not activated. Please provide an API key.');
-      reject(new Error('no api key'));
+    if (!isConfigured(this.config)) {
+      debug('GitEvents meetup.com plugin is not configured!');
+      reject(new Error('Meetup plugin is not configured'));
+      return;
     }
 
-    var meetup = require('meetup-api')({
-      key: config.plugins.meetup.apikey
+    if (!isEnabled(this.config)) {
+      debug('Plugin disabled. Exiting.');
+      reject(new Error('Meetup plugin is disabeld'));
+      return;
+    }
+
+    debug('Plugin enabled. Proceeding.');
+
+    var doorTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
+    var startTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
+    doorTime.hour(event.doorTime.split(':')[0]);
+    doorTime.minute(event.doorTime.split(':')[1]);
+    var differenceDoorStartTime = startTime.diff(doorTime);
+
+    var duration = moment.duration(event.duration);
+    duration.add(differenceDoorStartTime);
+
+    var meetupVenueId = resolveVenueId(event, this.config);
+
+    this.meetup.postEvent({
+      group_id: this.config.plugins.meetup.group_id,
+      name: event.name,
+      venue_visibility: 'public',
+      hosts: this.config.plugins.meetup.hosts.join(','),
+      group_urlname: event.organizer.url,
+      simple_html_description: this.config.plugins.meetup.simple_html_description,
+      time: doorTime.valueOf(),
+      duration: duration.asMilliseconds(),
+      publish_status: 'published',
+      venue_id: meetupVenueId
+    }, function(error, response) {
+      debug('Meetup:postEvent()');
+      if (error) {
+        debug(error);
+        return reject(error);
+      }
+      return resolve(response.id);
     });
+  }.bind(this));
+};
 
-    if (config.plugins.meetup.enabled === true) {
-      debug('plugin enabled. Proceeding.');
+meetup.getRSVPs = function getRSVPs(eventId) {
+  return new Promise(function(resolve, reject) {
+    debug('getRsvps');
 
-      var doorTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
-      var startTime = moment(event.startDate, 'YYYY-MM-DDTHH:mm:ss');
-      doorTime.hour(event.doorTime.split(':')[0]);
-      doorTime.minute(event.doorTime.split(':')[1]);
-      var differenceDoorStartTime = startTime.diff(doorTime);
+    if (!isConfigured(this.config)) {
+      debug('GitEvents meetup.com plugin is not configured!');
+      reject(new Error('Meetup plugin is not configured'));
+      return;
+    }
 
-      var duration = moment.duration(event.duration);
-      duration.add(differenceDoorStartTime);
-      var meetupVenueId;
+    if (!isEnabled(this.config)) {
+      debug('Plugin disabled. Exiting.');
+      reject(new Error('Meetup plugin is disabeld'));
+      return;
+    }
 
-      if (event.meetupVenueId) {
-        meetupVenueId = event.meetupVenueId;
-      } else {
-        meetupVenueId = config.plugins.meetup.default_venue_id;
+    debug('Plugin enabled. Proceeding.');
+
+    this.meetup.getRSVPs({
+      event_id: eventId
+    }, function(error, response) {
+      debug('Meetup:getRSVPs()');
+      if (error) {
+        debug(error);
+        return reject(error);
       }
 
-      meetup.postEvent({
-        group_id: config.plugins.meetup.group_id,
-        name: event.name,
-        venue_visibility: 'public',
-        hosts: config.plugins.meetup.hosts.join(','),
-        group_urlname: event.organizer.url,
-        simple_html_description: config.plugins.meetup.simple_html_description,
-        time: doorTime.valueOf(),
-        duration: duration.asMilliseconds(),
-        publish_status: 'published',
-        venue_id: meetupVenueId
-      }, function(error, response) {
-        debug('Meetup:postEvent()');
-        if (error) {
-          debug(error);
-          return reject(error);
-        }
-        return resolve(response.id);
+      var rsvps = response.results.map(function(result) {
+        return {
+          name: result.member.name,
+          response: result.response
+        };
       });
-    } else {
-      debug('plugin disabled. Exiting.');
-      return resolve('meetup plugin is disabeld.');
-    }
-  });
+
+      return resolve(rsvps);
+    });
+  }.bind(this));
 };
+
+function isConfigured(config) {
+  return Boolean(config.plugins.meetup);
+}
+
+function isEnabled(config) {
+  return config.plugins.meetup.enabled === true;
+}
+
+function resolveVenueId(event, config) {
+  if (event.meetupVenueId) {
+    return event.meetupVenueId;
+  }
+
+  return config.plugins.meetup.default_venue_id;
+}
 
 module.exports = exports = meetup;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "nock": "^3.6.0",
+    "sinon": "^1.17.2",
     "tape": "^4.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "request": "^2.67.0"
   },
   "devDependencies": {
-    "nock": "^3.6.0",
     "sinon": "^1.17.2",
     "tape": "^4.4.0"
   }

--- a/tests/data/rsvps.json
+++ b/tests/data/rsvps.json
@@ -1,0 +1,29 @@
+{
+  "results": [
+    {
+      "created": 1449151202000,
+      "response": "no",
+      "guests": 0,
+      "member": {
+        "member_id": 123,
+        "name": "Foo Bar"
+      },
+      "rsvp_id": 123123,
+      "mtime": 1449685902000,
+      "event": {
+        "name": "Some event",
+        "id": "1212121212",
+        "time": 1454446800000,
+        "event_url": "http://www.meetup.com/Test-Group/events/1212121212/"
+      },
+      "group": {
+        "join_mode": "open",
+        "created": 1453211766856,
+        "group_lon": -2.393,
+        "id": 987987,
+        "urlname": "Test-Group",
+        "group_lat": 5.102
+      }
+    }
+  ]
+}

--- a/tests/events.js
+++ b/tests/events.js
@@ -1,5 +1,6 @@
 var test = require('tape');
 var nock = require('nock');
+var sinon = require('sinon');
 var meetup = require('../index');
 
 test('create() function output type', assert => {
@@ -21,17 +22,10 @@ test('create() should not do anything if plugin is disabled', assert => {
   var event = require('./data/event');
 
   const actual = meetup.create(event);
-  const expected = 'meetup plugin is disabeld.';
 
-  // assert.equal(actual, expected, 'meetup.create()');
-  actual.then((actual) => {
-    assert.equal(actual, expected);
+  actual.catch((error) => {
     config.plugins.meetup.enabled = true;
-    assert.end();
-  });
-
-  actual.catch(() => {
-    assert.fail('should not get here.');
+    assert.equal(error.message, 'Meetup plugin is disabeld');
     assert.end();
   });
 });
@@ -41,51 +35,77 @@ test('create() should create an event on meetup.com', assert => {
   var event = require('./data/event');
   meetup.init(config);
 
-  nock('https://api.meetup.com:443', {
-      'encodedQueryParams': true
-    })
-    .post('/2/event')
-    .query({
-      'group_id': '18232090',
-      'name': 'BarcelonaJS%20Meetup.com',
-      'venue_visibility': 'public',
-      'hosts': '194993837',
-      'group_urlname': 'http%3A%2F%2Fbarcelonajs.org',
-      'simple_html_description': 'This%20slot%20could%20be%20yours!%20%3Ca%20href%3D%22https%3A%2F%2Fgithub.com%2FBarcelonaJS%2Fspeakers%22%3ESubmit%20your%20talk%20now%3C%2Fa%3E.%20You%20did%20some%20crazy%20stuff%20with%20JavaScript%3F%20You%20want%20to%20show%20it%20to%20the%20community%3F%20Drop%20us%20a%20line%20on%20your%20topic%20on%20%3Ca%20href%3D%22https%3A%2F%2Ftwitter.com%2Fbcnjs%22%3ETwitter%3C%2Fa%3E.',
-      'time': '4102422300000',
-      'duration': '8100000',
-      'publish_status': 'published',
-      'venue_id': '13033612',
-      'key': config.plugins.meetup.apikey
-    })
-    .reply(201, ['1f8b08000000000000037d53db6adb40107def574cf7d9d8d24ab664933ad0943e040285144a4120d6d238da44da5df612e1867c4f3fa43fd659d938090dd5839066e79c33337be68905dfd47abf77e8d9265b25f199b1475401d9e689353a286f0f6cc3d0b1196ba48fdf9f856db0d74a5048b4ad45e7ea94e27025ac450b5fb5f24261df8b19f01924659270a05c25068c69377a277b841fdaf62d5c212920080fdf7af1e7b720122ffaa00e224248856df83c2dd25551ce986cd926cd922c5ba59c0e05159da7f3ac5cadf37cc62c1aa91452ce5ef40e9f67ac43d14e3db04d6c4b3a49cac7264cd8f5b221895148df4be7eb97c4c6a2f09127cd976951f06cc9f992040771d8616ddda37995dca26bac345ec652d985d97eefa403d76b0f94441dee100e3a58f7112e047416f79f2ad6796fdca65a548b3be9bbb09b377aa816e7c15edf560b67503ca07515dbde86dd20fdc402349c07507abca816623b879f3a402b5b707a4068acf87500e7c37e0f23f1c2b57814b753759753e6289407afc1757a04397dfa8e707a1882a2b95cc217ab0d0407027aa910b43aa96a239bf8f75e0b9eb43cda630fbb46ddc79abf1f83c732e96db6346b2467f93ad89e2615f1137c1cc7f980e88379670a13c2550bce8ba22c8a55562d88e780eecd35a4740dc18ae31d94e9c9c642293a6ece86383bf09502dc9c95d9d15fec2c45012f23204f139e739e9d788369dfb5c79dd5c1c4b5b9d752d5836ea39636a8d81b4b1124e5699e4f5cff56c44e44f5d9fb936cb1e2eb6c9d2fb3d316943ce3c93a5663fbff919c7624aa25e9922fcba25c272bb27da709f26210721aa38d715ef8e0e824181a895477ecf9c35f91bd5fda26040000'], {
-      server: 'cloudflare-nginx',
-      date: 'Sat, 02 Jan 2016 22:05:52 GMT',
-      'content-type': 'application/json;charset=utf-8',
-      'content-length': '628',
-      connection: 'close',
-      'set-cookie': ['__cfduid=d598ac3395235c9d43849cdcc8024cbeb1451772351; expires=Sun, 01-Jan-17 22:05:51 GMT; path=/; domain=.meetup.com; HttpOnly'],
-      'x-meetup-server': 'api10',
-      'x-ratelimit-limit': '30',
-      'x-ratelimit-remaining': '29',
-      'x-ratelimit-reset': '10',
-      'x-oauth-scopes': 'basic',
-      'x-accepted-oauth-scopes': 'basic',
-      location: 'https://api.meetup.com/2/event/227787763',
-      vary: 'Accept-Encoding,User-Agent',
-      'content-encoding': 'gzip'
-    });
+  var mockError = null;
+  var mockResponse = { id: 123 };
 
-  const actual = meetup.create(event);
-  const expected = '227787763';
+  var postEventStub = sinon.stub(meetup.meetup, 'postEvent');
+  postEventStub.callsArgWith(1, mockError, mockResponse);
 
-  actual.then((actual) => {
-    assert.equal(actual, expected, 'returned meetup id should match');
+  meetup.create(event).then((eventId) => {
+    assert.equal(eventId, mockResponse.id, 'returned meetup id should match');
+
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('group_id', 18232090)), 'group id is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('name', 'BarcelonaJS Meetup.com')), 'name is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('venue_visibility', 'public')), 'venue visibility is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('hosts', '194993837')), 'hosts list is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('group_urlname', 'http://barcelonajs.org')), 'group url is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('simple_html_description', 'This slot could be yours! <a href="https://github.com/BarcelonaJS/speakers">Submit your talk now</a>. You did some crazy stuff with JavaScript? You want to show it to the community? Drop us a line on your topic on <a href="https://twitter.com/bcnjs">Twitter</a>.')), 'html description is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('time', 4102425900000)), 'event time is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('duration', 8100000)), 'event duration is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('publish_status', 'published')), 'publish status is passed to meetup client');
+    assert.ok(postEventStub.calledWith(sinon.match.hasOwn('venue_id', 13033612)), 'venue id is passed to meetup client');
     assert.end();
+  }).catch((error) => {
+    console.log(error);
   });
+});
 
-  actual.catch((error) => {
-    assert.fail('should not get here.');
+test('getRsvps() should return a list of attendees from meetup.com', assert => {
+  var config = require('../common/config');
+  meetup.init(config);
+
+  var mockError = null;
+  var mockResponse = {
+    results: [
+      {
+        created: 1449151202000,
+        response: 'no',
+        guests: 0,
+        member: {
+          member_id: 123,
+          name: 'Foo Bar'
+        },
+        rsvp_id: 123123,
+        mtime: 1449685902000,
+        event: {
+          name: 'Some event',
+          id: '1212121212',
+          time: 1454446800000,
+          event_url: 'http://www.meetup.com/Test-Group/events/1212121212/'
+        },
+        group: {
+          join_mode: 'open',
+          created: 1453211766856,
+          group_lon: -2.393,
+          id: 987987,
+          urlname: 'Test-Group',
+          group_lat: 5.102
+        }
+      }
+    ]
+  };
+
+  var getRSVPsStub = sinon.stub(meetup.meetup, 'getRSVPs');
+  getRSVPsStub.callsArgWith(1, mockError, mockResponse);
+
+  meetup.getRSVPs('123').then((rsvps) => {
+    assert.equal(rsvps.length, 1, 'returned answers are returned');
+    assert.equal(rsvps[0].name, 'Foo Bar', 'attendee name is returned');
+    assert.equal(rsvps[0].response, 'no', 'attendee response is returned');
+
+    assert.ok(getRSVPsStub.calledWith(sinon.match.hasOwn('event_id', '123')), 'event id is passed to meetup client');
     assert.end();
+  }).catch((error) => {
+    console.log(error);
   });
 });

--- a/tests/events.js
+++ b/tests/events.js
@@ -61,41 +61,13 @@ test('create() should create an event on meetup.com', assert => {
 
 test('getRsvps() should return a list of attendees from meetup.com', assert => {
   var config = require('../common/config');
+  var rsvps = require('./data/rsvps');
   meetup.init(config);
 
   var mockError = null;
-  var mockResponse = {
-    results: [
-      {
-        created: 1449151202000,
-        response: 'no',
-        guests: 0,
-        member: {
-          member_id: 123,
-          name: 'Foo Bar'
-        },
-        rsvp_id: 123123,
-        mtime: 1449685902000,
-        event: {
-          name: 'Some event',
-          id: '1212121212',
-          time: 1454446800000,
-          event_url: 'http://www.meetup.com/Test-Group/events/1212121212/'
-        },
-        group: {
-          join_mode: 'open',
-          created: 1453211766856,
-          group_lon: -2.393,
-          id: 987987,
-          urlname: 'Test-Group',
-          group_lat: 5.102
-        }
-      }
-    ]
-  };
 
   var getRSVPsStub = sinon.stub(meetup.meetup, 'getRSVPs');
-  getRSVPsStub.callsArgWith(1, mockError, mockResponse);
+  getRSVPsStub.callsArgWith(1, mockError, rsvps);
 
   meetup.getRSVPs('123').then((rsvps) => {
     assert.equal(rsvps.length, 1, 'returned answers are returned');

--- a/tests/events.js
+++ b/tests/events.js
@@ -1,5 +1,4 @@
 var test = require('tape');
-var nock = require('nock');
 var sinon = require('sinon');
 var meetup = require('../index');
 


### PR DESCRIPTION
Implements a `getRSVPs` method on the Meetup plugin. This method passes the call to a method with the same name on the `meetup-api` client and returns an array of response objects from the array. Each response consists of a name (i.e. attendee name) and response (`yes` or `no`).

In addition I've refactored the tests to not test at HTTP level with nock, but by stubbing the `meetup-api` client and spying calls made to it.
